### PR TITLE
refactor: trait abstractions for testable DB layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,9 +454,10 @@ dependencies = [
 
 [[package]]
 name = "db-migrator"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bb8",
  "bb8-tiberius",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "db-migrator"
-version = "0.2.5"
-edition = "2021"
+version = "0.3.0"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,6 +15,7 @@ clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4" }
 toml = "0.8"
 async-trait = "0.1"
+async-stream = "0.3"
 hex = "0.4"
 futures = "0.3"
 tiberius = { version = "0.12.3" }

--- a/src/common/schema.rs
+++ b/src/common/schema.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use tiberius::Row;
 
 use crate::common::constraints::Constraint;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use toml::Value;
 
 #[derive(Debug)]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bb8::Pool;
 use bb8_tiberius::ConnectionManager;
-use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions};
 use sqlx::ConnectOptions;
+use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions};
 use tiberius::{AuthMethod, Config, EncryptionLevel};
 
 use crate::config::DatabaseConfig;

--- a/src/extract/extractor.rs
+++ b/src/extract/extractor.rs
@@ -1,22 +1,28 @@
 use crate::common::schema::ColumnSchema;
 use crate::common::sql::{escape_mssql_identifier, escape_sql_string};
 use crate::extract::format::format_row_values;
-use anyhow::{anyhow, Context, Result};
-use bb8::{Pool, PooledConnection};
+use crate::extract::traits::Extractor;
+use anyhow::{Context, Result, anyhow};
+use async_stream::stream;
+use async_trait::async_trait;
+use bb8::Pool;
 use bb8_tiberius::ConnectionManager;
 use futures::stream::{BoxStream, StreamExt};
 
 #[derive(Clone)]
 pub struct DatabaseExtractor {
-    pub pool: Pool<ConnectionManager>,
+    pool: Pool<ConnectionManager>,
 }
 
 impl DatabaseExtractor {
     pub fn new(pool: Pool<ConnectionManager>) -> Self {
         DatabaseExtractor { pool }
     }
+}
 
-    pub async fn fetch_tables(&mut self) -> Result<Vec<String>> {
+#[async_trait]
+impl Extractor for DatabaseExtractor {
+    async fn fetch_tables(&self) -> Result<Vec<String>> {
         let mut conn = self.pool.get().await?;
 
         let rows = conn
@@ -42,10 +48,10 @@ impl DatabaseExtractor {
         Ok(tables)
     }
 
-    pub async fn get_table_schema(&mut self, table: &str) -> Result<Vec<ColumnSchema>> {
+    async fn get_table_schema(&self, table: &str) -> Result<Vec<ColumnSchema>> {
         let mut conn = self.pool.get().await?;
 
-        let query = format !(
+        let query = format!(
             "SELECT
                 c.COLUMN_NAME,
                 c.DATA_TYPE,
@@ -86,23 +92,38 @@ impl DatabaseExtractor {
 
         Ok(schema)
     }
-}
 
-pub async fn open_row_stream<'a>(
-    conn: &'a mut PooledConnection<'_, ConnectionManager>,
-    table: &'a str,
-) -> Result<BoxStream<'a, Result<Vec<String>, anyhow::Error>>> {
-    let query = format!("SELECT * FROM {}", escape_mssql_identifier(table));
-    let stream = conn
-        .simple_query(query)
-        .await?
-        .into_row_stream()
-        .map(|row_result| {
-            row_result
-                .map_err(anyhow::Error::from)
-                .and_then(format_row_values)
-        })
-        .boxed();
+    async fn stream_rows(&self, table: &str) -> Result<BoxStream<'static, Result<Vec<String>>>> {
+        let pool = self.pool.clone();
+        let table = table.to_owned();
 
-    Ok(stream)
+        let stream = stream! {
+            let conn_result = pool.get().await;
+            let mut conn = match conn_result {
+                Ok(conn) => conn,
+                Err(e) => {
+                    yield Err(anyhow::Error::from(e));
+                    return;
+                }
+            };
+
+            let query = format!("SELECT * FROM {}", escape_mssql_identifier(&table));
+            let query_stream = match conn.simple_query(query).await {
+                Ok(qs) => qs.into_row_stream(),
+                Err(e) => {
+                    yield Err(anyhow::Error::from(e));
+                    return;
+                }
+            };
+
+            futures::pin_mut!(query_stream);
+            while let Some(row_result) = query_stream.next().await {
+                yield row_result
+                    .map_err(anyhow::Error::from)
+                    .and_then(format_row_values);
+            }
+        };
+
+        Ok(Box::pin(stream))
+    }
 }

--- a/src/extract/format.rs
+++ b/src/extract/format.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::DateTime as ChronosDateTime;
 use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use hex::encode;

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,2 +1,3 @@
 pub mod extractor;
 mod format;
+pub mod traits;

--- a/src/extract/traits.rs
+++ b/src/extract/traits.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use crate::common::schema::ColumnSchema;
+
+#[async_trait]
+pub trait Extractor: Clone + Send + Sync + 'static {
+    async fn fetch_tables(&self) -> Result<Vec<String>>;
+    async fn get_table_schema(&self, table: &str) -> Result<Vec<ColumnSchema>>;
+    async fn stream_rows(&self, table: &str) -> Result<BoxStream<'static, Result<Vec<String>>>>;
+}

--- a/src/insert/inserter.rs
+++ b/src/insert/inserter.rs
@@ -1,4 +1,5 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
+use async_trait::async_trait;
 use sqlx::{Acquire, Executor, MySqlPool, Row};
 
 use crate::common::sql::{escape_mysql_identifier, escape_sql_string};
@@ -6,6 +7,7 @@ use crate::common::sql::{escape_mysql_identifier, escape_sql_string};
 use crate::common::schema::ColumnSchema;
 use crate::insert::query::{build_create_constraints, build_create_table_query, build_reset_query};
 use crate::insert::table_action::TableAction;
+use crate::insert::traits::Inserter;
 
 #[derive(Clone)]
 pub struct DatabaseInserter {
@@ -17,7 +19,18 @@ impl DatabaseInserter {
         DatabaseInserter { pool }
     }
 
-    pub async fn create_table(&mut self, table_name: &str, schema: &[ColumnSchema]) -> Result<()> {
+    async fn get_all_tables(&self) -> Result<Vec<String>> {
+        let rows = sqlx::query("SHOW TABLES").fetch_all(&self.pool).await?;
+
+        let table_names: Vec<String> = rows.iter().map(|row| row.get::<String, _>(0)).collect();
+
+        Ok(table_names)
+    }
+}
+
+#[async_trait]
+impl Inserter for DatabaseInserter {
+    async fn create_table(&self, table_name: &str, schema: &[ColumnSchema]) -> Result<()> {
         let create_table_query = build_create_table_query(table_name, schema);
 
         debug!("Creating table {}", table_name);
@@ -31,8 +44,8 @@ impl DatabaseInserter {
         Ok(())
     }
 
-    pub async fn create_constraints(
-        &mut self,
+    async fn create_constraints(
+        &self,
         table_name: &str,
         schema: &[ColumnSchema],
         formatted_tables: &[String],
@@ -72,7 +85,7 @@ impl DatabaseInserter {
         Ok(())
     }
 
-    pub async fn execute_transactional_query(&mut self, query: &str) -> Result<()> {
+    async fn execute_transactional_query(&self, query: &str) -> Result<()> {
         let mut connection = self.pool.acquire().await?;
         let mut transaction = connection.begin().await?;
 
@@ -97,7 +110,7 @@ impl DatabaseInserter {
         Ok(())
     }
 
-    pub async fn get_max_allowed_packet(&mut self) -> Result<usize> {
+    async fn get_max_allowed_packet(&self) -> Result<usize> {
         let query = "SELECT @@max_allowed_packet";
 
         let max_allowed_packet: u32 = sqlx::query_scalar(query).fetch_one(&self.pool).await?;
@@ -105,10 +118,10 @@ impl DatabaseInserter {
         Ok(max_allowed_packet as usize)
     }
 
-    pub async fn reset_tables(&mut self, tables: &[String], action: TableAction) -> Result<()> {
-        let mut all_tables = self.get_all_tables().await.with_context(|| {
-            "Resetting tables encountered an error, cannot obtain existing tables"
-        })?;
+    async fn reset_tables(&self, tables: &[String], action: TableAction) -> Result<()> {
+        let mut all_tables = self.get_all_tables().await.with_context(
+            || "Resetting tables encountered an error, cannot obtain existing tables",
+        )?;
 
         // Filter and keep only the tables that exist in the database and are also present in the `tables` slice
         all_tables.retain(|table| {
@@ -136,15 +149,7 @@ impl DatabaseInserter {
         Ok(())
     }
 
-    async fn get_all_tables(&mut self) -> Result<Vec<String>> {
-        let rows = sqlx::query("SHOW TABLES").fetch_all(&self.pool).await?;
-
-        let table_names: Vec<String> = rows.iter().map(|row| row.get::<String, _>(0)).collect();
-
-        Ok(table_names)
-    }
-
-    pub async fn table_exists(&mut self, table_name: &str) -> Result<bool> {
+    async fn table_exists(&self, table_name: &str) -> Result<bool> {
         let query = format!(
             "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '{}'",
             escape_sql_string(table_name)
@@ -155,7 +160,7 @@ impl DatabaseInserter {
         Ok(count > 0)
     }
 
-    pub async fn table_rows_count(&mut self, table_name: &str) -> Result<i64> {
+    async fn table_rows_count(&self, table_name: &str) -> Result<i64> {
         let query = format!(
             "SELECT COUNT(*) FROM {}",
             escape_mysql_identifier(table_name)

--- a/src/insert/mod.rs
+++ b/src/insert/mod.rs
@@ -1,3 +1,4 @@
 pub mod inserter;
 pub mod query;
 pub mod table_action;
+pub mod traits;

--- a/src/insert/query.rs
+++ b/src/insert/query.rs
@@ -117,10 +117,10 @@ pub fn build_create_table_query(table_name: &str, schema: &[ColumnSchema]) -> St
                 }
             }
 
-            if let Some(constraint) = &column.constraints {
-                if *constraint == Constraint::PrimaryKey {
-                    result_str.push_str(" PRIMARY KEY");
-                }
+            if let Some(constraint) = &column.constraints
+                && *constraint == Constraint::PrimaryKey
+            {
+                result_str.push_str(" PRIMARY KEY");
             }
 
             result_str.push(' ');

--- a/src/insert/traits.rs
+++ b/src/insert/traits.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::common::schema::ColumnSchema;
+use crate::insert::table_action::TableAction;
+
+#[async_trait]
+pub trait Inserter: Clone + Send + Sync + 'static {
+    async fn create_table(&self, name: &str, schema: &[ColumnSchema]) -> Result<()>;
+    async fn create_constraints(
+        &self,
+        name: &str,
+        schema: &[ColumnSchema],
+        tables: &[String],
+    ) -> Result<()>;
+    async fn execute_transactional_query(&self, query: &str) -> Result<()>;
+    async fn get_max_allowed_packet(&self) -> Result<usize>;
+    async fn reset_tables(&self, tables: &[String], action: TableAction) -> Result<()>;
+    async fn table_exists(&self, name: &str) -> Result<bool>;
+    async fn table_rows_count(&self, name: &str) -> Result<i64>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn run(options: Args) -> Result<()> {
         whitelisted_tables: config.settings().whitelisted_tables.clone(),
     };
 
-    let mut migrator = DatabaseMigrator::new(extractor, inserter, mappings, migration_options);
+    let migrator = DatabaseMigrator::new(extractor, inserter, mappings, migration_options);
 
     migrator.run().await.with_context(|| "Migration failed")?;
 

--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug)]

--- a/src/migrate/constraints_creator.rs
+++ b/src/migrate/constraints_creator.rs
@@ -3,20 +3,20 @@ use futures::future::join_all;
 use tokio::spawn;
 
 use crate::common::helpers::print_error_chain;
-use crate::insert::inserter::DatabaseInserter;
+use crate::insert::traits::Inserter;
 use crate::migrate::migration_result::MigrationResult;
 
-pub struct ConstraintsCreator {
-    inserter: DatabaseInserter,
+pub struct ConstraintsCreator<I: Inserter> {
+    inserter: I,
 }
 
-impl ConstraintsCreator {
-    pub fn new(inserter: DatabaseInserter) -> Self {
+impl<I: Inserter> ConstraintsCreator<I> {
+    pub fn new(inserter: I) -> Self {
         ConstraintsCreator { inserter }
     }
 
     pub async fn run(
-        &mut self,
+        &self,
         successful_results: Vec<MigrationResult>,
         formatted_tables: Vec<String>,
     ) {
@@ -24,7 +24,7 @@ impl ConstraintsCreator {
             .into_iter()
             .filter(|migration_result| migration_result.created)
             .map(|migration_result| {
-                let mut inserter = self.inserter.clone();
+                let inserter = self.inserter.clone();
                 let formatted_tables = formatted_tables.clone();
                 let table_name = migration_result.table_name.clone();
                 let schema = migration_result.schema;

--- a/src/migrate/migrator.rs
+++ b/src/migrate/migrator.rs
@@ -1,36 +1,31 @@
 use std::sync::Arc;
 
-use anyhow::{bail, Context, Error, Result};
+use anyhow::{Context, Error, Result, bail};
 use log::info;
 use tokio::spawn;
-use tokio::sync::{watch, Semaphore};
+use tokio::sync::{Semaphore, watch};
 use tokio::time::Instant;
 
 use crate::common::errors::MigrationError;
 use crate::common::helpers::format_snake_case;
-use crate::extract::extractor::DatabaseExtractor;
-use crate::insert::inserter::DatabaseInserter;
+use crate::extract::traits::Extractor;
 use crate::insert::table_action::TableAction;
+use crate::insert::traits::Inserter;
 use crate::mappings::Mappings;
 use crate::migrate::constraints_creator::ConstraintsCreator;
 use crate::migrate::migration_options::MigrationOptions;
 use crate::migrate::migration_result::MigrationResult;
 use crate::migrate::table_migrator::TableMigrator;
 
-pub struct DatabaseMigrator {
-    extractor: DatabaseExtractor,
-    inserter: DatabaseInserter,
+pub struct DatabaseMigrator<E: Extractor, I: Inserter> {
+    extractor: E,
+    inserter: I,
     mappings: Mappings,
     options: MigrationOptions,
 }
 
-impl DatabaseMigrator {
-    pub fn new(
-        extractor: DatabaseExtractor,
-        inserter: DatabaseInserter,
-        mappings: Mappings,
-        options: MigrationOptions,
-    ) -> Self {
+impl<E: Extractor, I: Inserter> DatabaseMigrator<E, I> {
+    pub fn new(extractor: E, inserter: I, mappings: Mappings, options: MigrationOptions) -> Self {
         DatabaseMigrator {
             extractor,
             inserter,
@@ -39,7 +34,7 @@ impl DatabaseMigrator {
         }
     }
 
-    pub async fn run(&mut self) -> Result<()> {
+    pub async fn run(&self) -> Result<()> {
         info!("Running table migrator");
 
         let config_send_packet_size = self.options.max_packet_bytes;
@@ -52,7 +47,7 @@ impl DatabaseMigrator {
         Ok(())
     }
 
-    pub async fn migrate_tables(&mut self) -> Result<()> {
+    pub async fn migrate_tables(&self) -> Result<()> {
         let start_time = Instant::now();
 
         let (tables, formatted_tables) = self.fetch_and_format_tables().await?;
@@ -70,7 +65,7 @@ impl DatabaseMigrator {
         let successful_results = self.run_migration(&tables).await?;
 
         if self.options.constraints {
-            let mut constraints_creator = ConstraintsCreator::new(self.inserter.clone());
+            let constraints_creator = ConstraintsCreator::new(self.inserter.clone());
             constraints_creator
                 .run(successful_results, formatted_tables)
                 .await;
@@ -86,7 +81,7 @@ impl DatabaseMigrator {
         Ok(())
     }
 
-    async fn fetch_and_format_tables(&mut self) -> Result<(Vec<String>, Vec<String>)> {
+    async fn fetch_and_format_tables(&self) -> Result<(Vec<String>, Vec<String>)> {
         let mut tables = self.extractor.fetch_tables().await?;
 
         if tables.is_empty() {
@@ -95,14 +90,12 @@ impl DatabaseMigrator {
 
         check_missing_tables(&tables, &self.options.whitelisted_tables);
 
-        // Filter and keep only the whitelisted tables
         tables.retain(|table| self.options.whitelisted_tables.contains(table));
 
         if tables.is_empty() {
             bail!("No tables to process after filtering whitelisted tables");
         }
 
-        // Compute formatted names AFTER filtering to avoid referencing non-migrated tables
         let formatted_tables = format_table_names(&tables, self.options.format_snake_case);
 
         info!("Tables to migrate: {}", tables.join(", "));
@@ -110,16 +103,14 @@ impl DatabaseMigrator {
         Ok((tables, formatted_tables))
     }
 
-    async fn run_migration(&mut self, tables: &[String]) -> Result<Vec<MigrationResult>> {
+    async fn run_migration(&self, tables: &[String]) -> Result<Vec<MigrationResult>> {
         let semaphore = Arc::new(Semaphore::new(self.options.max_concurrent_tasks));
 
-        // Channel to signal cancellation when a task fails
         let (cancel_tx, cancel_rx) = watch::channel(false);
 
         let mut migration_tasks = Vec::new();
         let mut successful_results = Vec::new();
 
-        // Spawn tasks for all tables
         for table in tables {
             let semaphore_clone = Arc::clone(&semaphore);
             let mut cancel_rx = cancel_rx.clone();
@@ -132,23 +123,20 @@ impl DatabaseMigrator {
             let table_name = table.clone();
 
             let task = spawn(async move {
-                // Wait for semaphore permit, but also check for cancellation
                 let permit = tokio::select! {
                     permit = semaphore_clone.acquire() => {
                         permit.map_err(|_| anyhow::anyhow!("Semaphore closed"))?
                     }
                     _ = cancel_rx.changed() => {
-                        // Another task failed, skip this table
                         return Ok(None);
                     }
                 };
 
-                // Check if cancelled before starting work
                 if *cancel_rx.borrow() {
                     return Ok(None);
                 }
 
-                let mut table_migrator = TableMigrator::new(extractor, inserter, mappings, options);
+                let table_migrator = TableMigrator::new(extractor, inserter, mappings, options);
 
                 let result = table_migrator
                     .migrate_table(&table)
@@ -162,7 +150,6 @@ impl DatabaseMigrator {
             migration_tasks.push((table_name, task));
         }
 
-        // Collect results as they complete, fail fast on first error
         let mut first_error: Option<Error> = None;
         let mut skipped_tables: Vec<String> = Vec::new();
 
@@ -174,12 +161,10 @@ impl DatabaseMigrator {
                     successful_results.push(migration_result);
                 }
                 Ok(Ok(None)) => {
-                    // Task was cancelled before starting
                     skipped_tables.push(table_name);
                 }
                 Ok(Err(err)) => {
                     if first_error.is_none() {
-                        // Signal all pending tasks to cancel
                         let _ = cancel_tx.send(true);
                         first_error = Some(err);
                     }

--- a/src/migrate/table_migrator.rs
+++ b/src/migrate/table_migrator.rs
@@ -6,9 +6,9 @@ use tokio::time::Instant;
 use crate::common::errors::MigrationError;
 use crate::common::helpers::format_snake_case;
 use crate::common::schema::ColumnSchema;
-use crate::extract::extractor::{open_row_stream, DatabaseExtractor};
-use crate::insert::inserter::DatabaseInserter;
+use crate::extract::traits::Extractor;
 use crate::insert::query::build_insert_statement;
+use crate::insert::traits::Inserter;
 use crate::mappings::Mappings;
 use crate::migrate::migration_options::MigrationOptions;
 use crate::migrate::migration_result::MigrationResult;
@@ -16,20 +16,15 @@ use crate::migrate::table_schema_mapper::TableSchemaMapper;
 
 const RESERVED_BYTES: usize = 10;
 
-pub struct TableMigrator {
-    extractor: DatabaseExtractor,
-    inserter: DatabaseInserter,
+pub struct TableMigrator<E: Extractor, I: Inserter> {
+    extractor: E,
+    inserter: I,
     mappings: Mappings,
     options: MigrationOptions,
 }
 
-impl TableMigrator {
-    pub fn new(
-        extractor: DatabaseExtractor,
-        inserter: DatabaseInserter,
-        mappings: Mappings,
-        options: MigrationOptions,
-    ) -> Self {
+impl<E: Extractor, I: Inserter> TableMigrator<E, I> {
+    pub fn new(extractor: E, inserter: I, mappings: Mappings, options: MigrationOptions) -> Self {
         TableMigrator {
             extractor,
             inserter,
@@ -38,7 +33,7 @@ impl TableMigrator {
         }
     }
 
-    pub async fn migrate_table(&mut self, table_name: &str) -> Result<MigrationResult> {
+    pub async fn migrate_table(&self, table_name: &str) -> Result<MigrationResult> {
         let output_table_name = if self.options.format_snake_case {
             format_snake_case(table_name)
         } else {
@@ -49,7 +44,6 @@ impl TableMigrator {
 
         let start_time = Instant::now();
 
-        // Fetch and map table schema
         let table_schema = self
             .extractor
             .get_table_schema(table_name)
@@ -90,7 +84,6 @@ impl TableMigrator {
                 .with_context(|| format!("Failed to create table '{}'", output_table_name))?;
         }
 
-        // Migrate rows from input table to output table
         let migrated_count = self
             .migrate_table_rows(table_name, &output_table_name, &mapped_schema)
             .await
@@ -112,7 +105,7 @@ impl TableMigrator {
     }
 
     async fn migrate_table_rows(
-        &mut self,
+        &self,
         input_table: &str,
         output_table: &str,
         mapped_schema: &[ColumnSchema],
@@ -121,8 +114,7 @@ impl TableMigrator {
 
         let insert_statement = build_insert_statement(output_table, mapped_schema);
 
-        let mut conn = self.extractor.pool.get().await?;
-        let mut stream = open_row_stream(&mut conn, input_table).await?;
+        let mut stream = self.extractor.stream_rows(input_table).await?;
 
         let mut insert_query = String::with_capacity(self.options.max_packet_bytes);
         let mut total_bytes = insert_statement.len();
@@ -135,7 +127,7 @@ impl TableMigrator {
             let value_set_bytes = value_set.len();
 
             if RESERVED_BYTES + total_bytes + value_set_bytes > self.options.max_packet_bytes {
-                execute_batch(&mut self.inserter, &insert_query, transaction_count).await?;
+                execute_batch(&self.inserter, &insert_query, transaction_count).await?;
 
                 total_transaction_count += transaction_count;
                 insert_query.clear();
@@ -158,7 +150,7 @@ impl TableMigrator {
         }
 
         if transaction_count > 0 {
-            execute_batch(&mut self.inserter, &insert_query, transaction_count).await?;
+            execute_batch(&self.inserter, &insert_query, transaction_count).await?;
             total_transaction_count += transaction_count;
         }
 
@@ -166,8 +158,8 @@ impl TableMigrator {
     }
 }
 
-async fn execute_batch(
-    inserter: &mut DatabaseInserter,
+async fn execute_batch<I: Inserter>(
+    inserter: &I,
     insert_query: &str,
     transaction_count: usize,
 ) -> Result<(), Error> {

--- a/src/migrate/table_schema_mapper.rs
+++ b/src/migrate/table_schema_mapper.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::common::constraints::Constraint;
 use crate::common::errors::MigrationError;


### PR DESCRIPTION
## Summary

- Define `Extractor` and `Inserter` traits behind which `DatabaseExtractor` and `DatabaseInserter` implement their DB operations
- Make `DatabaseMigrator`, `TableMigrator`, and `ConstraintsCreator` generic over these traits, enabling mock-based unit testing of orchestration logic without real databases
- `stream_rows` returns `BoxStream<'static>` via `async_stream::stream!`, owning its pooled connection inside the stream
- Remove direct pool access (`open_row_stream`, `pub pool`) — all DB interaction goes through trait methods
- Bump version to `0.3.0`, edition to `2024`

## What changed

| File | Change |
|------|--------|
| `src/extract/traits.rs` | New `Extractor` trait |
| `src/insert/traits.rs` | New `Inserter` trait |
| `src/extract/extractor.rs` | Implements `Extractor`, `pool` now private, `stream_rows` rewritten |
| `src/insert/inserter.rs` | Implements `Inserter` |
| `src/migrate/migrator.rs` | `DatabaseMigrator<E, I>` generic |
| `src/migrate/table_migrator.rs` | `TableMigrator<E, I>` generic, uses `stream_rows` |
| `src/migrate/constraints_creator.rs` | `ConstraintsCreator<I>` generic |
| `src/main.rs` | `let mut migrator` → `let migrator` |
| `Cargo.toml` | version 0.3.0, edition 2024, add async-stream |
| Various | `cargo fmt` import reordering (edition 2024) |

## What does NOT change

- Concurrency model (semaphore + spawned tasks + fail-fast via watch channel)
- Row batching logic (packet size limits, INSERT construction)
- Constraint creation (best-effort, errors logged)
- All existing 113 tests pass

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] `cargo test` — 113 tests pass
- [ ] Smoke test against real MSSQL → MySQL migration (recommended before merge)